### PR TITLE
Add strict spelling

### DIFF
--- a/bot/cogs/check.py
+++ b/bot/cogs/check.py
@@ -78,10 +78,11 @@ class Check(commands.Cog):
                     with open(filename, 'rb') as img:
                         await ctx.send(file=discord.File(img, filename="award.png"))
 
-                if database.exists(f"race.data:{ctx.channel.id}") and str(
+                if (
+                    database.exists(f"race.data:{ctx.channel.id}") and
                     database.hget(f"race.data:{ctx.channel.id}", "media")
-                )[2:-1] == "image":
-
+                    .decode("utf-8") == "image"
+                ):
                     limit = int(database.hget(f"race.data:{ctx.channel.id}", "limit"))
                     first = database.zrevrange(f"race.scores:{ctx.channel.id}", 0, 0, True)[0]
                     if int(first[1]) >= limit:
@@ -215,9 +216,11 @@ class Check(commands.Cog):
                     with open(filename, 'rb') as img:
                         await ctx.send(file=discord.File(img, filename="award.png"))
 
-                if database.exists(f"race.data:{ctx.channel.id}") and str(
+                if (
+                    database.exists(f"race.data:{ctx.channel.id}") and
                     database.hget(f"race.data:{ctx.channel.id}", "media")
-                )[2:-1] == "song":
+                    .decode("utf-8") == "song"
+                ):
 
                     limit = int(database.hget(f"race.data:{ctx.channel.id}", "limit"))
                     first = database.zrevrange(f"race.scores:{ctx.channel.id}", 0, 0, True)[0]

--- a/bot/cogs/check.py
+++ b/bot/cogs/check.py
@@ -48,12 +48,22 @@ class Check(commands.Cog):
 
             bird_setup(ctx, currentBird)
 
-            if database.hget(f"session.data:{ctx.author.id}", "strict"):
-                logger.info("strict spelling")
-                correct = arg == currentBird or arg == sciBird
+            if database.exists(f"race.data:{ctx.channel.id}"):
+                logger.info("race in session")
+                if database.hget(f"race.data:{ctx.channel.id}", "strict"):
+                    logger.info("strict spelling")
+                    correct = arg == currentBird or arg == sciBird
+                else:
+                    logger.info("spelling leniency")
+                    correct = spellcheck(arg, currentBird) or spellcheck(arg, sciBird)
             else:
-                logger.info("spelling leniency")
-                correct = spellcheck(arg, currentBird) or spellcheck(arg, sciBird)
+                logger.info("no race")
+                if database.hget(f"session.data:{ctx.author.id}", "strict"):
+                    logger.info("strict spelling")
+                    correct = arg == currentBird or arg == sciBird
+                else:
+                    logger.info("spelling leniency")
+                    correct = spellcheck(arg, currentBird) or spellcheck(arg, sciBird)
 
             if correct:
                 logger.info("correct")
@@ -186,12 +196,22 @@ class Check(commands.Cog):
 
             bird_setup(ctx, currentSongBird)
 
-            if database.hget(f"session.data:{ctx.author.id}", "strict"):
-                logger.info("strict spelling")
-                correct = arg == currentSongBird or arg == sciBird
+            if database.exists(f"race.data:{ctx.channel.id}"):
+                logger.info("race in session")
+                if database.hget(f"race.data:{ctx.channel.id}", "strict"):
+                    logger.info("strict spelling")
+                    correct = arg == currentSongBird or arg == sciBird
+                else:
+                    logger.info("spelling leniency")
+                    correct = spellcheck(arg, currentSongBird) or spellcheck(arg, sciBird)
             else:
-                logger.info("spelling leniency")
-                correct = spellcheck(arg, currentSongBird) or spellcheck(arg, sciBird)
+                logger.info("no race")
+                if database.hget(f"session.data:{ctx.author.id}", "strict"):
+                    logger.info("strict spelling")
+                    correct = arg == currentSongBird or arg == sciBird
+                else:
+                    logger.info("spelling leniency")
+                    correct = spellcheck(arg, currentSongBird) or spellcheck(arg, sciBird)
             
             if correct:
                 logger.info("correct")

--- a/bot/cogs/check.py
+++ b/bot/cogs/check.py
@@ -40,12 +40,22 @@ class Check(commands.Cog):
         if currentBird == "":  # no bird
             await ctx.send("You must ask for a bird first!")
         else:  # if there is a bird, it checks answer
-            logger.info("currentBird: " + str(currentBird.lower().replace("-", " ")))
-            logger.info("args: " + str(arg.lower().replace("-", " ")))
+            sciBird = (await get_sciname(currentBird)).lower().replace("-", " ")
+            arg = arg.lower().replace("-", " ")
+            currentBird = currentBird.lower().replace("-", " ")
+            logger.info("currentBird: " + currentBird)
+            logger.info("arg: " + arg)
 
             bird_setup(ctx, currentBird)
-            sciBird = await get_sciname(currentBird)
-            if spellcheck(arg, currentBird) or spellcheck(arg, sciBird):
+
+            if database.hget(f"session.data:{ctx.author.id}", "strict"):
+                logger.info("strict spelling")
+                correct = arg == currentBird or arg == sciBird
+            else:
+                logger.info("spelling leniency")
+                correct = spellcheck(arg, currentBird) or spellcheck(arg, sciBird)
+
+            if correct:
                 logger.info("correct")
 
                 database.hset(f"channel:{ctx.channel.id}", "bird", "")
@@ -96,7 +106,7 @@ class Check(commands.Cog):
                 else:
                     database.hset(f"channel:{ctx.channel.id}", "bird", "")
                     database.hset(f"channel:{ctx.channel.id}", "answered", "1")
-                    await ctx.send("Sorry, the bird was actually " + currentBird.lower() + ".")
+                    await ctx.send("Sorry, the bird was actually " + currentBird + ".")
                     url = get_wiki_url(ctx, currentBird)
                     await ctx.send(url)
 
@@ -110,12 +120,26 @@ class Check(commands.Cog):
         if currentBird == "":  # no bird
             await ctx.send("You must ask for a bird first!")
         else:  # if there is a bird, it checks answer
-            bird_setup(ctx, currentBird)
             index = goatsuckers.index(currentBird)
-            sciBird = sciGoat[index]
+            sciBird = (sciGoat[index]).lower().replace("-", " ")
+            args = arg.lower().replace("-", " ")
+            currentBird = currentBird.lower().replace("-", " ")
+            logger.info("currentBird: " + currentBird)
+            logger.info("arg: " + arg)
+
+            bird_setup(ctx, currentBird)
+
             database.hset(f"channel:{ctx.channel.id}", "gsAnswered", "1")
             database.hset(f"channel:{ctx.channel.id}", "goatsucker", "")
-            if spellcheck(arg, currentBird) or spellcheck(arg, sciBird):
+
+            if database.hget(f"session.data:{ctx.author.id}", "strict"):
+                logger.info("strict spelling")
+                correct = arg == currentBird or arg == sciBird
+            else:
+                logger.info("spelling leniency")
+                correct = spellcheck(arg, currentBird) or spellcheck(arg, sciBird)
+
+            if correct:
                 logger.info("correct")
 
                 session_increment(ctx, "correct", 1)
@@ -139,11 +163,9 @@ class Check(commands.Cog):
                 session_increment(ctx, "incorrect", 1)
                 incorrect_increment(ctx, str(currentBird), 1)
 
-                await ctx.send("Sorry, the bird was actually " + currentBird.lower() + ".")
+                await ctx.send("Sorry, the bird was actually " + currentBird + ".")
                 url = get_wiki_url(ctx, currentBird)
                 await ctx.send(url)
-            logger.info("currentBird: " + str(currentBird.lower().replace("-", " ")))
-            logger.info("args: " + str(arg.lower().replace("-", " ")))
 
     # Check command - argument is the guess
     @commands.command(help='- Checks the song', aliases=["songcheck", "cs", "sc"])
@@ -155,12 +177,22 @@ class Check(commands.Cog):
         if currentSongBird == "":  # no bird
             await ctx.send("You must ask for a bird call first!")
         else:  # if there is a bird, it checks answer
-            logger.info("currentBird: " + str(currentSongBird.lower().replace("-", " ")))
-            logger.info("args: " + str(arg.lower().replace("-", " ")))
+            sciBird = (await get_sciname(currentSongBird)).lower().replace("-", " ")
+            arg = arg.lower().replace("-", " ")
+            currentSongBird = currentSongBird.lower().replace("-", " ")
+            logger.info("currentSongBird: " + currentSongBird)
+            logger.info("args: " + arg)
 
             bird_setup(ctx, currentSongBird)
-            sciBird = await get_sciname(currentSongBird)
-            if spellcheck(arg, currentSongBird) or spellcheck(arg, sciBird):
+
+            if database.hget(f"session.data:{ctx.author.id}", "strict"):
+                logger.info("strict spelling")
+                correct = arg == currentSongBird or arg == sciBird
+            else:
+                logger.info("spelling leniency")
+                correct = spellcheck(arg, currentSongBird) or spellcheck(arg, sciBird)
+            
+            if correct:
                 logger.info("correct")
 
                 database.hset(f"channel:{ctx.channel.id}", "sBird", "")
@@ -210,7 +242,7 @@ class Check(commands.Cog):
                 else:
                     database.hset(f"channel:{ctx.channel.id}", "sBird", "")
                     database.hset(f"channel:{ctx.channel.id}", "sAnswered", "1")
-                    await ctx.send("Sorry, the bird was actually " + currentSongBird.lower() + ".")
+                    await ctx.send("Sorry, the bird was actually " + currentSongBird + ".")
                     url = get_wiki_url(ctx, currentSongBird)
                     await ctx.send(url)
 

--- a/bot/cogs/check.py
+++ b/bot/cogs/check.py
@@ -133,7 +133,7 @@ class Check(commands.Cog):
         else:  # if there is a bird, it checks answer
             index = goatsuckers.index(currentBird)
             sciBird = (sciGoat[index]).lower().replace("-", " ")
-            args = arg.lower().replace("-", " ")
+            arg = arg.lower().replace("-", " ")
             currentBird = currentBird.lower().replace("-", " ")
             logger.info("currentBird: " + currentBird)
             logger.info("arg: " + arg)

--- a/bot/cogs/race.py
+++ b/bot/cogs/race.py
@@ -29,14 +29,18 @@ class Race(commands.Cog):
         self.bot = bot
 
     async def _get_options(self, ctx):
-        bw, addon, state, media, limit, taxon = database.hmget(
-            f"race.data:{ctx.channel.id}", ["bw", "addon", "state", "media", "limit", "taxon"]
+        bw, addon, state, media, limit, taxon, strict = database.hmget(
+            f"race.data:{ctx.channel.id}",
+            ["bw", "addon", "state", "media", "limit", "taxon", "strict"]
         )
         options = str(
-            f"**Age/Sex:** {addon.decode('utf-8') if addon else 'default'}\n" + f"**Black & White:** {bw==b'bw'}\n" +
+            f"**Age/Sex:** {addon.decode('utf-8') if addon else 'default'}\n" +
+            f"**Black & White:** {bw==b'bw'}\n" +
             f"**Special bird list:** {state.decode('utf-8') if state else 'None'}\n" +
             f"**Taxons:** {taxon.decode('utf-8') if taxon else 'None'}\n" +
-            f"**Media Type:** {media.decode('utf-8')}\n" + f"**Amount to Win:** {limit.decode('utf-8')}\n"
+            f"**Media Type:** {media.decode('utf-8')}\n" + 
+            f"**Amount to Win:** {limit.decode('utf-8')}\n" +
+            f"**Strict Spelling:** {strict == b'strict'}"
         )
         return options
 
@@ -131,7 +135,7 @@ class Race(commands.Cog):
     @race.command(
         brief="- Starts race",
         help="""- Starts race.
-        Arguments passed will become the default arguments to 'b!bird', but can be manually overwritten during use.
+        Arguments passed will become the default arguments to 'b!bird', but some can be manually overwritten during use.
         Arguments can be passed in any taxon.
         However, having both females and juveniles are not supported.""",
         aliases=["st"],
@@ -166,6 +170,11 @@ class Race(commands.Cog):
                 taxon = " ".join(taxon_args).strip()
             else:
                 taxon = ""
+
+            if "strict" in args:
+                strict = "strict"
+            else:
+                strict = ""
 
             states_args = set(states.keys()).intersection({arg.upper() for arg in args})
             if states_args:
@@ -234,7 +243,8 @@ class Race(commands.Cog):
                     "state": state,
                     "addon": addon,
                     "media": media,
-                    "taxon": taxon
+                    "taxon": taxon,
+                    "strict": strict
                 }
             )
 

--- a/bot/cogs/race.py
+++ b/bot/cogs/race.py
@@ -33,7 +33,7 @@ class Race(commands.Cog):
             f"race.data:{ctx.channel.id}",
             ["bw", "addon", "state", "media", "limit", "taxon", "strict"]
         )
-        options = str(
+        options = (
             f"**Age/Sex:** {addon.decode('utf-8') if addon else 'default'}\n" +
             f"**Black & White:** {bw==b'bw'}\n" +
             f"**Special bird list:** {state.decode('utf-8') if state else 'None'}\n" +

--- a/bot/cogs/skip.py
+++ b/bot/cogs/skip.py
@@ -30,7 +30,7 @@ class Skip(commands.Cog):
     async def skip(self, ctx):
         logger.info("command: skip")
 
-        currentBird = str(database.hget(f"channel:{ctx.channel.id}", "bird"))[2:-1]
+        currentBird = database.hget(f"channel:{ctx.channel.id}", "bird").decode("utf-8")
         database.hset(f"channel:{ctx.channel.id}", "bird", "")
         database.hset(f"channel:{ctx.channel.id}", "answered", "1")
         if currentBird != "":  # check if there is bird
@@ -61,7 +61,7 @@ class Skip(commands.Cog):
     async def skipgoat(self, ctx):
         logger.info("command: skipgoat")
 
-        currentBird = str(database.hget(f"channel:{ctx.channel.id}", "goatsucker"))[2:-1]
+        currentBird = database.hget(f"channel:{ctx.channel.id}", "goatsucker").decode("utf-8")
         database.hset(f"channel:{ctx.channel.id}", "goatsucker", "")
         database.hset(f"channel:{ctx.channel.id}", "gsAnswered", "1")
         if currentBird != "":  # check if there is bird
@@ -78,7 +78,7 @@ class Skip(commands.Cog):
     async def skipsong(self, ctx):
         logger.info("command: skipsong")
 
-        currentSongBird = str(database.hget(f"channel:{ctx.channel.id}", "sBird"))[2:-1]
+        currentSongBird = database.hget(f"channel:{ctx.channel.id}", "sBird").decode("utf-8")
         database.hset(f"channel:{ctx.channel.id}", "sBird", "")
         database.hset(f"channel:{ctx.channel.id}", "sAnswered", "1")
         if currentSongBird != "":  # check if there is bird
@@ -86,9 +86,11 @@ class Skip(commands.Cog):
             await ctx.send(f"Ok, skipping {currentSongBird.lower()}")
             await ctx.send(url if not database.exists(f"race.data:{ctx.channel.id}") else f"<{url}>")  # sends wiki page
             streak_increment(ctx, None) # reset streak
-            if database.exists(f"race.data:{ctx.channel.id}") and str(
+            if (
+                database.exists(f"race.data:{ctx.channel.id}") and
                 database.hget(f"race.data:{ctx.channel.id}", "media")
-            )[2:-1] == "song":
+                .decode("utf-8") == "song"
+            ):
 
                 limit = int(database.hget(f"race.data:{ctx.channel.id}", "limit"))
                 first = database.zrevrange(f"race.scores:{ctx.channel.id}", 0, 0, True)[0]

--- a/bot/core.py
+++ b/bot/core.py
@@ -361,7 +361,7 @@ async def get_image(ctx, bird, addOn=None):
         sciBird = bird
     images = await get_files(sciBird, "images", addOn)
     logger.info("images: " + str(images))
-    prevJ = int(str(database.hget(f"channel:{ctx.channel.id}", "prevJ"))[2:-1])
+    prevJ = int(database.hget(f"channel:{ctx.channel.id}", "prevJ"))
     # Randomize start (choose beginning 4/5ths in case it fails checks)
     if images:
         j = (prevJ + 1) % len(images)
@@ -406,7 +406,7 @@ async def get_song(ctx, bird):
         sciBird = bird
     songs = await get_files(sciBird, "songs")
     logger.info("songs: " + str(songs))
-    prevK = int(str(database.hget(f"channel:{ctx.channel.id}", "prevK"))[2:-1])
+    prevK = int(database.hget(f"channel:{ctx.channel.id}", "prevK"))
     if songs:
         k = (prevK + 1) % len(songs)
         logger.info("prevK: " + str(prevK))

--- a/bot/data/__init__.py
+++ b/bot/data/__init__.py
@@ -78,16 +78,17 @@ if os.getenv("SCIOLY_ID_BOT_USE_SENTRY") != "false":
 # }
 
 # session format:
-# session.data:user_id : {"start": 0,
-#                         "stop": 0,
-#                         "correct": 0,
-#                         "incorrect": 0,
-#                         "total": 0,
-#                         "bw": bw, - Toggles if "bw", doesn't if empty (""), default ""
-#                         "state": state,
-#                         "addon": addon,
-#                         "wiki": wiki, - Enables if "wiki", disables if empty (""), default "wiki"
-#                         "strict": strict - Enables strict spelling if "strict", disables if empty, default ""
+# session.data:user_id : {
+#                    "start": 0,
+#                    "stop": 0,
+#                    "correct": 0,
+#                    "incorrect": 0,
+#                    "total": 0,
+#                    "bw": bw, - Toggles if "bw", doesn't if empty (""), default ""
+#                    "state": state,
+#                    "addon": addon,
+#                    "wiki": wiki, - Enables if "wiki", disables if empty (""), default "wiki"
+#                    "strict": strict - Enables strict spelling if "strict", disables if empty, default ""
 # }
 # session.incorrect:user_id : [bird name, # incorrect]
 
@@ -100,7 +101,8 @@ if os.getenv("SCIOLY_ID_BOT_USE_SENTRY") != "false":
 #                    "state": state,
 #                    "addon": addon,
 #                    "media": media,
-#                    "taxon": taxon
+#                    "taxon": taxon,
+#                    "strict": strict - Enables strict spelling if "strict", disables if empty, default ""
 # }
 # race.scores:ctx.channel.id : [ctx.author.id, #correct]
 

--- a/bot/data/__init__.py
+++ b/bot/data/__init__.py
@@ -78,9 +78,17 @@ if os.getenv("SCIOLY_ID_BOT_USE_SENTRY") != "false":
 # }
 
 # session format:
-# session.data:user_id : {"start": 0, "stop": 0,
-#                         "correct": 0, "incorrect": 0, "total": 0,
-#                         "bw": bw, "state": state, "addon": addon}
+# session.data:user_id : {"start": 0,
+#                         "stop": 0,
+#                         "correct": 0,
+#                         "incorrect": 0,
+#                         "total": 0,
+#                         "bw": bw, - Toggles if "bw", doesn't if empty (""), default ""
+#                         "state": state,
+#                         "addon": addon,
+#                         "wiki": wiki, - Enables if "wiki", disables if empty (""), default "wiki"
+#                         "strict": strict - Enables strict spelling if "strict", disables if empty, default ""
+# }
 # session.incorrect:user_id : [bird name, # incorrect]
 
 # race format:

--- a/web/practice.py
+++ b/web/practice.py
@@ -68,7 +68,7 @@ def get_bird():
         file_object, ext = asyncio.run(
             send_bird(
                 database.hget(f"web.session:{session_id}", "bird").decode("utf-8"),
-                str(database.hget(f"web.session:{session_id}", "media_type"))[2:-1], addon, bw
+                database.hget(f"web.session:{session_id}", "media_type").decode("utf-8"), addon, bw
             )
         )
 


### PR DESCRIPTION
Add session/race settings for strict spelling. This option forces users to spell the names of the birds correctly. However, capitalization still doesn't matter, both scientific and common names are accepted, and hyphens/spaces are interchangeable. Proper apostrophes are still required.

Race level settings override session settings to ensure a level playing field.