### PR TITLE
Add support for slash commands

### DIFF
--- a/bot/__main__.py
+++ b/bot/__main__.py
@@ -141,7 +141,7 @@ if __name__ == "__main__":
     ######
 
     @bot.check
-    async def prechecks(ctx):
+    async def prechecks(ctx: discord.Context):
         if ctx.interaction is None:
             await ctx.typing()
 
@@ -212,7 +212,7 @@ if __name__ == "__main__":
     # GLOBAL ERROR CHECKING
     ######
     @bot.event
-    async def on_command_error(ctx, error):
+    async def on_command_error(ctx: commands.Context, error):
         """Handles errors for all commands without local error handlers."""
         logger.info("Error: " + str(error))
 

--- a/bot/__main__.py
+++ b/bot/__main__.py
@@ -142,7 +142,8 @@ if __name__ == "__main__":
 
     @bot.check
     async def prechecks(ctx):
-        await ctx.typing()
+        if ctx.interaction is None:
+            await ctx.typing()
 
         logger.info("global check: checking permissions")
         await commands.bot_has_permissions(
@@ -151,8 +152,15 @@ if __name__ == "__main__":
 
         logger.info("global check: checking banned")
         if database.zscore("ignore:global", str(ctx.channel.id)) is not None:
+            if ctx.interaction is not None:
+                await ctx.send(
+                    "The owner of the server has disabled commands in this channel.",
+                    ephemeral=True,
+                )
             raise GenericError(code=192)
         if database.zscore("banned:global", str(ctx.author.id)) is not None:
+            if ctx.interaction is not None:
+                await ctx.send("You cannot use this command!", ephemeral=True)
             raise GenericError(code=842)
 
         logger.info("global check: logging command frequency")

--- a/bot/cogs/check.py
+++ b/bot/cogs/check.py
@@ -59,7 +59,7 @@ class Check(commands.Cog):
     @commands.check(CustomCooldown(3.0, bucket=commands.BucketType.user))
     @app_commands.rename(arg="guess")
     @app_commands.describe(arg="your answer")
-    async def check(self, ctx, *, arg: str):
+    async def check(self, ctx: commands.Context, *, arg: str):
         logger.info("command: check")
 
         currentBird = database.hget(f"channel:{ctx.channel.id}", "bird").decode("utf-8")

--- a/bot/cogs/check.py
+++ b/bot/cogs/check.py
@@ -19,6 +19,7 @@ from difflib import get_close_matches
 
 import discord
 import discord.ext.commands.view
+from discord import app_commands
 from discord.ext import commands
 
 import bot.voice as voice_functions
@@ -52,11 +53,13 @@ class Check(commands.Cog):
         self.bot = bot
 
     # Check command - argument is the guess
-    @commands.command(
+    @commands.hybrid_command(
         help="- Checks your answer.", usage="guess", aliases=["guess", "c"]
     )
     @commands.check(CustomCooldown(3.0, bucket=commands.BucketType.user))
-    async def check(self, ctx, *, arg):
+    @app_commands.rename(arg="guess")
+    @app_commands.describe(arg="your answer")
+    async def check(self, ctx, *, arg: str):
         logger.info("command: check")
 
         currentBird = database.hget(f"channel:{ctx.channel.id}", "bird").decode("utf-8")

--- a/bot/cogs/check.py
+++ b/bot/cogs/check.py
@@ -18,6 +18,7 @@ import string
 from difflib import get_close_matches
 
 import discord
+import discord.ext.commands.view
 from discord.ext import commands
 
 import bot.voice as voice_functions
@@ -202,11 +203,12 @@ class Check(commands.Cog):
                 message=message,
                 bot=self.bot,
                 prefix="race-autocheck",
+                view=discord.ext.commands.view.StringView(""),
             )
             await self.check(ctx, arg=message.content)
 
 
-def setup(bot):
+async def setup(bot):
     cog = Check(bot)
     bot.add_message_handler(cog.race_autocheck)
-    bot.add_cog(cog)
+    await bot.add_cog(cog)

--- a/bot/cogs/covid.py
+++ b/bot/cogs/covid.py
@@ -232,5 +232,5 @@ class COVID(commands.Cog):
         await ctx.send("Ok, done!")
 
 
-def setup(bot):
-    bot.add_cog(COVID(bot))
+async def setup(bot):
+    await bot.add_cog(COVID(bot))

--- a/bot/cogs/get_birds.py
+++ b/bot/cogs/get_birds.py
@@ -477,5 +477,5 @@ class Birds(commands.Cog):
             )
 
 
-def setup(bot):
-    bot.add_cog(Birds(bot))
+async def setup(bot):
+    await bot.add_cog(Birds(bot))

--- a/bot/cogs/get_birds.py
+++ b/bot/cogs/get_birds.py
@@ -18,13 +18,14 @@ import random
 import string
 from typing import Optional
 
+from discord import app_commands
 from discord.ext import commands
 
 import bot.voice as voice_functions
 from bot.core import send_bird
 from bot.data import GenericError, database, goatsuckers, logger, states, taxons
 from bot.data_functions import bird_setup, session_increment
-from bot.filters import Filter, MediaType
+from bot.filters import Filter, MediaType, arg_autocomplete
 from bot.functions import CustomCooldown, build_id_list, check_state_role
 
 BASE_MESSAGE = (
@@ -226,7 +227,7 @@ class Birds(commands.Cog):
                 return
 
             if len(birds) < 5:
-                logger.info(f"list less than 5 items")
+                logger.info("list less than 5 items")
                 await ctx.send(
                     "**Sorry, you must have at least 5 birds in the taxon/state combo."
                     + "**\n*Please try again with a different set of taxons/lists.*"
@@ -400,13 +401,18 @@ class Birds(commands.Cog):
 
     # Bird command - no args
     # help text
-    @commands.command(
+    @commands.hybrid_command(
         help="- Sends a random bird image for you to ID",
         aliases=["b"],
         usage="[filters] [order/family] [state]",
     )
     # 5 second cooldown
     @commands.check(CustomCooldown(5.0, bucket=commands.BucketType.channel))
+    @app_commands.rename(args_str="options")
+    @app_commands.describe(
+        args_str="Macaulay Library filters, bird lists, or taxons. Muliple options can be used at once (even if it doesn't autocomplete)"
+    )
+    @app_commands.autocomplete(args_str=arg_autocomplete)
     async def bird(self, ctx, *, args_str: str = ""):
         logger.info("command: bird")
 
@@ -419,12 +425,17 @@ class Birds(commands.Cog):
         await self.send_bird_(ctx, media, filters, taxon, state)
 
     # picks a random bird call to send
-    @commands.command(
+    @commands.hybrid_command(
         help="- Sends a random bird song for you to ID",
         aliases=["s"],
         usage="[filters] [order/family] [state]",
     )
     @commands.check(CustomCooldown(5.0, bucket=commands.BucketType.channel))
+    @app_commands.rename(args_str="options")
+    @app_commands.describe(
+        args_str="Macaulay Library filters, bird lists, or taxons. Muliple options can be used at once (even if it doesn't autocomplete)"
+    )
+    @app_commands.autocomplete(args_str=arg_autocomplete)
     async def song(self, ctx, *, args_str: str = ""):
         logger.info("command: song")
 
@@ -438,7 +449,7 @@ class Birds(commands.Cog):
 
     # goatsucker command - no args
     # just for fun, no real purpose
-    @commands.command(help="- Sends a random goatsucker to ID", aliases=["gs"])
+    @commands.hybrid_command(help="- Sends a random goatsucker to ID", aliases=["gs"])
     @commands.check(CustomCooldown(5.0, bucket=commands.BucketType.channel))
     async def goatsucker(self, ctx):
         logger.info("command: goatsucker")

--- a/bot/cogs/get_birds.py
+++ b/bot/cogs/get_birds.py
@@ -413,7 +413,7 @@ class Birds(commands.Cog):
         args_str="Macaulay Library filters, bird lists, or taxons. Muliple options can be used at once (even if it doesn't autocomplete)"
     )
     @app_commands.autocomplete(args_str=arg_autocomplete)
-    async def bird(self, ctx, *, args_str: str = ""):
+    async def bird(self, ctx: commands.Context, *, args_str: str = ""):
         logger.info("command: bird")
 
         filters, taxon, state = await self.parse(ctx, args_str)
@@ -436,7 +436,7 @@ class Birds(commands.Cog):
         args_str="Macaulay Library filters, bird lists, or taxons. Muliple options can be used at once (even if it doesn't autocomplete)"
     )
     @app_commands.autocomplete(args_str=arg_autocomplete)
-    async def song(self, ctx, *, args_str: str = ""):
+    async def song(self, ctx: commands.Context, *, args_str: str = ""):
         logger.info("command: song")
 
         filters, taxon, state = await self.parse(ctx, args_str)
@@ -451,7 +451,7 @@ class Birds(commands.Cog):
     # just for fun, no real purpose
     @commands.hybrid_command(help="- Sends a random goatsucker to ID", aliases=["gs"])
     @commands.check(CustomCooldown(5.0, bucket=commands.BucketType.channel))
-    async def goatsucker(self, ctx):
+    async def goatsucker(self, ctx: commands.Context):
         logger.info("command: goatsucker")
 
         if database.exists(f"race.data:{ctx.channel.id}"):

--- a/bot/cogs/hint.py
+++ b/bot/cogs/hint.py
@@ -37,5 +37,5 @@ class Hint(commands.Cog):
             await ctx.send("You need to ask for a bird first!")
 
 
-def setup(bot):
-    bot.add_cog(Hint(bot))
+async def setup(bot):
+    await bot.add_cog(Hint(bot))

--- a/bot/cogs/hint.py
+++ b/bot/cogs/hint.py
@@ -25,9 +25,9 @@ class Hint(commands.Cog):
         self.bot = bot
 
     # give hint
-    @commands.command(help="- Gives first letter of current bird", aliases=["h"])
+    @commands.hybrid_command(help="- Gives first letter of current bird", aliases=["h"])
     @commands.check(CustomCooldown(3.0, bucket=commands.BucketType.channel))
-    async def hint(self, ctx):
+    async def hint(self, ctx: commands.Context):
         logger.info("command: hint")
 
         currentBird = database.hget(f"channel:{ctx.channel.id}", "bird").decode("utf-8")

--- a/bot/cogs/meta.py
+++ b/bot/cogs/meta.py
@@ -263,5 +263,5 @@ class Meta(commands.Cog):
         )
 
 
-def setup(bot):
-    bot.add_cog(Meta(bot))
+async def setup(bot):
+    await bot.add_cog(Meta(bot))

--- a/bot/cogs/meta.py
+++ b/bot/cogs/meta.py
@@ -35,7 +35,7 @@ class Meta(commands.Cog):
         aliases=["bot_info", "support"],
     )
     @commands.check(CustomCooldown(5.0, bucket=commands.BucketType.channel))
-    async def botinfo(self, ctx):
+    async def botinfo(self, ctx: commands.Context):
         logger.info("command: botinfo")
 
         embed = discord.Embed(type="rich", colour=discord.Color.blurple())
@@ -76,7 +76,7 @@ class Meta(commands.Cog):
         help="- Pings the bot and displays latency",
     )
     @commands.check(CustomCooldown(3.0, bucket=commands.BucketType.channel))
-    async def ping(self, ctx):
+    async def ping(self, ctx: commands.Context):
         logger.info("command: ping")
         lat = round(self.bot.latency * 1000)
         logger.info(f"latency: {lat}")
@@ -85,7 +85,7 @@ class Meta(commands.Cog):
     # invite command - sends invite link
     @commands.hybrid_command(help="- Get the invite link for this bot")
     @commands.check(CustomCooldown(5.0, bucket=commands.BucketType.channel))
-    async def invite(self, ctx):
+    async def invite(self, ctx: commands.Context):
         logger.info("command: invite")
 
         embed = discord.Embed(type="rich", colour=discord.Color.blurple())
@@ -110,7 +110,11 @@ class Meta(commands.Cog):
     @commands.guild_only()
     @commands.has_guild_permissions(manage_guild=True)
     @app_commands.default_permissions(manage_guild=True)
-    async def ignore(self, ctx, channels: commands.Greedy[discord.TextChannel] = None):
+    async def ignore(
+        self,
+        ctx: commands.Context,
+        channels: commands.Greedy[discord.TextChannel] = None,
+    ):
         logger.info("command: ignore")
 
         added = []
@@ -163,7 +167,7 @@ class Meta(commands.Cog):
     @commands.guild_only()
     @commands.has_guild_permissions(manage_guild=True)
     @app_commands.default_permissions(manage_guild=True)
-    async def noholiday(self, ctx):
+    async def noholiday(self, ctx: commands.Context):
         logger.info("command: noholiday")
 
         if not database.sismember("noholiday:global", str(ctx.guild.id)):
@@ -183,7 +187,9 @@ class Meta(commands.Cog):
     @commands.guild_only()
     @commands.has_guild_permissions(manage_guild=True)
     @app_commands.default_permissions(manage_guild=True)
-    async def leave(self, ctx, confirm: typing.Optional[bool] = False):
+    async def leave(
+        self, ctx: commands.Context, confirm: typing.Optional[bool] = False
+    ):
         logger.info("command: leave")
 
         if database.exists(f"leave:{ctx.guild.id}"):
@@ -212,7 +218,7 @@ class Meta(commands.Cog):
     @commands.is_owner()
     async def ban(
         self,
-        ctx,
+        ctx: commands.Context,
         *,
         user: typing.Optional[typing.Union[discord.Member, discord.User]] = None,
     ):
@@ -230,7 +236,7 @@ class Meta(commands.Cog):
     @commands.is_owner()
     async def unban(
         self,
-        ctx,
+        ctx: commands.Context,
         *,
         user: typing.Optional[typing.Union[discord.Member, discord.User]] = None,
     ):
@@ -248,7 +254,7 @@ class Meta(commands.Cog):
     @commands.is_owner()
     async def correct(
         self,
-        ctx,
+        ctx: commands.Context,
         *,
         user: typing.Optional[typing.Union[discord.Member, discord.User]] = None,
     ):
@@ -268,7 +274,7 @@ class Meta(commands.Cog):
 
     @commands.command(hidden=True)
     @commands.is_owner()
-    async def sync(self, ctx):
+    async def sync(self, ctx: commands.Context):
         logger.info("command: sync")
         sync = await self.bot.tree.sync()
         await ctx.send(f"Synced {len(sync)} commands")

--- a/bot/cogs/other.py
+++ b/bot/cogs/other.py
@@ -37,33 +37,11 @@ from bot.data import (
     states,
     taxons,
 )
-from bot.filters import Filter, MediaType
+from bot.filters import Filter, MediaType, state_autocomplete, taxon_autocomplete
 from bot.functions import CustomCooldown, build_id_list, cache, decrypt_chacha
 
 # Discord max message length is 2000 characters, leave some room just in case
 MAX_MESSAGE = 1900
-
-
-async def state_autocomplete(
-    _: discord.Interaction,
-    current: str,
-) -> list[app_commands.Choice[str]]:
-    return [
-        app_commands.Choice(name=state, value=state)
-        for state in states
-        if current.lower() in state.lower()
-    ][:25]
-
-
-async def taxon_autocomplete(
-    _: discord.Interaction,
-    current: str,
-) -> list[app_commands.Choice[str]]:
-    return [
-        app_commands.Choice(name=taxon, value=taxon)
-        for taxon in taxons
-        if current.lower() in taxon.lower()
-    ][:25]
 
 
 class Other(commands.Cog):

--- a/bot/cogs/other.py
+++ b/bot/cogs/other.py
@@ -101,7 +101,7 @@ class Other(commands.Cog):
     @commands.check(CustomCooldown(5.0, bucket=commands.BucketType.user))
     @app_commands.rename(arg="bird_and_filters")
     @app_commands.describe(arg="The bird name must come before any options.")
-    async def info(self, ctx, *, arg):
+    async def info(self, ctx: commands.Context, *, arg):
         logger.info("command: info")
         arg = arg.lower().strip()
 
@@ -194,7 +194,7 @@ class Other(commands.Cog):
         code="The asset code to search for.",
         bird="The bird name that corresponds to the asset.",
     )
-    async def asset(self, ctx, code: str, *, bird: str):
+    async def asset(self, ctx: commands.Context, code: str, *, bird: str):
         logger.info("command: asset")
 
         guess = bird.strip().lower().replace("-", " ").strip()
@@ -234,7 +234,7 @@ class Other(commands.Cog):
         help="- Lists available Macaulay Library filters.", aliases=["filter"]
     )
     @commands.check(CustomCooldown(8.0, bucket=commands.BucketType.user))
-    async def filters(self, ctx):
+    async def filters(self, ctx: commands.Context):
         logger.info("command: filters")
         filters = Filter.aliases()
         embed = discord.Embed(
@@ -265,7 +265,7 @@ class Other(commands.Cog):
     @commands.check(CustomCooldown(5.0, bucket=commands.BucketType.user))
     @app_commands.describe(state="The specific bird list.")
     @app_commands.autocomplete(state=state_autocomplete)
-    async def list_of_birds(self, ctx, state: str = "NATS"):
+    async def list_of_birds(self, ctx: commands.Context, state: str = "NATS"):
         logger.info("command: list")
 
         state = state.upper()
@@ -323,7 +323,7 @@ class Other(commands.Cog):
     @app_commands.autocomplete(taxon=taxon_autocomplete, state=state_autocomplete)
     async def bird_taxons(
         self,
-        ctx,
+        ctx: commands.Context,
         taxon: str,
         state: str = "NATS",
     ):
@@ -406,7 +406,7 @@ class Other(commands.Cog):
     @commands.check(CustomCooldown(5.0, bucket=commands.BucketType.user))
     @app_commands.rename(arg="query")
     @app_commands.describe(arg="A Wikipedia query")
-    async def wikipedia(self, ctx, *, arg):
+    async def wikipedia(self, ctx: commands.Context, *, arg):
         logger.info("command: wiki")
         try:
             url = get_wiki_url(arg)
@@ -425,14 +425,14 @@ class Other(commands.Cog):
     @commands.check(
         CustomCooldown(180.0, disable=True, bucket=commands.BucketType.user)
     )
-    async def meme(self, ctx):
+    async def meme(self, ctx: commands.Context):
         logger.info("command: meme")
         await ctx.send(random.choice(memeList))
 
     # Send command - for testing purposes only
     @commands.command(help="- send command", hidden=True, aliases=["sendas"])
     @commands.is_owner()
-    async def send_as_bot(self, ctx, *, args):
+    async def send_as_bot(self, ctx: commands.Context, *, args):
         logger.info("command: send")
         logger.info(f"args: {args}")
         channel_id = int(args.split(" ")[0])
@@ -444,7 +444,7 @@ class Other(commands.Cog):
     # # Test command - for testing purposes only
     # @commands.command(help="- test command", hidden=True)
     # @commands.is_owner()
-    # async def cache(self, ctx):
+    # async def cache(self, ctx: commands.Context):
     #     logger.info("command: cache stats")
     #     items = []
     #     with contextlib.suppress(FileNotFoundError):
@@ -461,7 +461,7 @@ class Other(commands.Cog):
     # # Test command - for testing purposes only
     # @commands.command(help="- test command", hidden=True)
     # @commands.is_owner()
-    # async def error(self, ctx):
+    # async def error(self, ctx: commands.Context):
     #     logger.info("command: error")
     #     await ctx.send(1 / 0)
 

--- a/bot/cogs/other.py
+++ b/bot/cogs/other.py
@@ -14,19 +14,19 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import contextlib
-import os
+# import contextlib
+# import os
 import random
 import string
-import typing
 from difflib import get_close_matches
 
 import aiohttp
 import discord
 import wikipedia
+from discord import app_commands
 from discord.ext import commands
 
-from bot.core import better_spellcheck, get_sciname, get_taxon, send_bird
+from bot.core import better_spellcheck, get_sciname, send_bird
 from bot.data import (
     alpha_codes,
     birdListMaster,
@@ -42,6 +42,28 @@ from bot.functions import CustomCooldown, build_id_list, cache, decrypt_chacha
 
 # Discord max message length is 2000 characters, leave some room just in case
 MAX_MESSAGE = 1900
+
+
+async def state_autocomplete(
+    _: discord.Interaction,
+    current: str,
+) -> list[app_commands.Choice[str]]:
+    return [
+        app_commands.Choice(name=state, value=state)
+        for state in states
+        if current.lower() in state.lower()
+    ][:25]
+
+
+async def taxon_autocomplete(
+    _: discord.Interaction,
+    current: str,
+) -> list[app_commands.Choice[str]]:
+    return [
+        app_commands.Choice(name=taxon, value=taxon)
+        for taxon in taxons
+        if current.lower() in taxon.lower()
+    ][:25]
 
 
 class Other(commands.Cog):
@@ -70,13 +92,15 @@ class Other(commands.Cog):
         return pages
 
     # Info - Gives call+image of 1 bird
-    @commands.command(
+    @commands.hybrid_command(
         brief="- Gives an image and call of a bird",
         help="- Gives an image and call of a bird. The bird name must come before any options.",
         usage="[bird] [options]",
         aliases=["i"],
     )
     @commands.check(CustomCooldown(5.0, bucket=commands.BucketType.user))
+    @app_commands.rename(arg="bird_and_filters")
+    @app_commands.describe(arg="The bird name must come before any options.")
     async def info(self, ctx, *, arg):
         logger.info("command: info")
         arg = arg.lower().strip()
@@ -84,7 +108,7 @@ class Other(commands.Cog):
         filters = Filter.parse(arg)
         if filters.vc:
             filters.vc = False
-            await ctx.send("**The VC filter is not allowed here!**")
+            await ctx.send("**The VC filter is not allowed here!**", ephemeral=True)
 
         options = filters.display()
         arg = arg.split(" ")
@@ -108,12 +132,19 @@ class Other(commands.Cog):
                     break
 
         if not bird:
-            await ctx.send("Bird not found. Are you sure it's on the list?")
+            await ctx.send(
+                "Bird not found. Are you sure it's on the list?", ephemeral=True
+            )
             return
 
-        delete = await ctx.send("Please wait a moment.")
+        if ctx.interaction is None:
+            delete = await ctx.send("Please wait a moment.")
+        else:
+            await ctx.typing()
+
+        output_message = ""
         if options:
-            await ctx.send(f"**Detected filters**: `{'`, `'.join(options)}`")
+            output_message += f"**Detected filters**: `{'`, `'.join(options)}`\n"
 
         an = "an" if bird.lower()[0] in ("a", "e", "i", "o", "u") else "a"
         await send_bird(
@@ -121,16 +152,17 @@ class Other(commands.Cog):
             bird,
             MediaType.IMAGE,
             filters,
-            message=f"Here's {an} *{bird.lower()}* image!",
+            message=output_message + f"Here's {an} *{bird.lower()}* image!",
         )
         await send_bird(
             ctx,
             bird,
             MediaType.SONG,
             filters,
-            message=f"Here's {an} *{bird.lower()}* song!",
+            message=output_message + f"Here's {an} *{bird.lower()}* song!",
         )
-        await delete.delete()
+        if ctx.interaction is None:
+            await delete.delete()
         return
 
     @staticmethod
@@ -153,26 +185,31 @@ class Other(commands.Cog):
         return currentBird
 
     # Asset command - gives original Macaulay Library asset from asset code
-    @commands.command(
+    @commands.hybrid_command(
         help="- Gives the original Macaulay Library asset from an asset code",
         aliases=["source", "original", "orig"],
     )
     @commands.check(CustomCooldown(5.0, bucket=commands.BucketType.user))
-    async def asset(self, ctx, *, arg):
+    @app_commands.describe(
+        code="The asset code to search for.",
+        bird="The bird name that corresponds to the asset.",
+    )
+    async def asset(self, ctx, code: str, *, bird: str):
         logger.info("command: asset")
 
-        arg = arg.strip().split(" ")
-        code = arg[0]
-        guess = " ".join(arg[1:]).lower().replace("-", " ").strip()
+        guess = bird.strip().lower().replace("-", " ").strip()
         if not guess:
-            await ctx.send("Please provide the bird name to get the original asset.")
+            await ctx.send(
+                "Please provide the bird name to get the original asset.",
+                ephemeral=True,
+            )
             return
 
         try:
             asset = str(int(decrypt_chacha(code).hex(), 16))
             currentBird = await self.bird_from_asset(asset)
-        except:
-            await ctx.send("**Invalid asset code!**")
+        except ValueError:
+            await ctx.send("**Invalid asset code!**", ephemeral=True)
             return
 
         url = f"https://www.macaulaylibrary.org/asset/{asset}/"
@@ -185,14 +222,15 @@ class Other(commands.Cog):
             or guess.upper() == alpha_code
         )
         if correct or ((await self.bot.is_owner(ctx.author)) and guess == "please"):
-            await ctx.send(f"**Here you go!** {url}")
+            await ctx.send(f"**Here you go!**\n{url}")
         else:
             await ctx.send(
-                f"**Sorry, that's not the correct bird.**\n*Please try again.*"
+                "**Sorry, that's not the correct bird.**\n*Please try again.*",
+                ephemeral=True,
             )
 
     # Filter command - lists available Macaulay Library filters and aliases
-    @commands.command(
+    @commands.hybrid_command(
         help="- Lists available Macaulay Library filters.", aliases=["filter"]
     )
     @commands.check(CustomCooldown(8.0, bucket=commands.BucketType.user))
@@ -221,11 +259,13 @@ class Other(commands.Cog):
         await ctx.send(embed=embed)
 
     # List command - argument is state/bird list
-    @commands.command(
+    @commands.hybrid_command(
         help="- DMs the user with the appropriate bird list.", name="list"
     )
     @commands.check(CustomCooldown(5.0, bucket=commands.BucketType.user))
-    async def list_of_birds(self, ctx, state: str = "blank"):
+    @app_commands.describe(state="The specific bird list.")
+    @app_commands.autocomplete(state=state_autocomplete)
+    async def list_of_birds(self, ctx, state: str = "NATS"):
         logger.info("command: list")
 
         state = state.upper()
@@ -233,9 +273,13 @@ class Other(commands.Cog):
         if state not in states:
             logger.info("invalid state")
             await ctx.send(
-                f"**Sorry, `{state}` is not a valid state.**\n*Valid States:* `{', '.join(map(str, list(states.keys())))}`"
+                f"**Sorry, `{state}` is not a valid list.**\n*Valid Lists:* `{', '.join(map(str, list(states.keys())))}`",
+                ephemeral=True,
             )
             return
+
+        if ctx.interaction is not None:
+            await ctx.typing()
 
         state_birdlist = sorted(
             build_id_list(
@@ -267,13 +311,22 @@ class Other(commands.Cog):
         )
 
     # taxons command - argument is state/bird list
-    @commands.command(
+    @commands.hybrid_command(
         help="- DMs the user with the appropriate bird list.",
         name="taxon",
         aliases=["taxons", "orders", "families", "order", "family"],
     )
     @commands.check(CustomCooldown(5.0, bucket=commands.BucketType.user))
-    async def bird_taxons(self, ctx, taxon: str = "blank", state: str = "NATS"):
+    @app_commands.describe(
+        taxon="The specific bird taxon", state="The specific bird list."
+    )
+    @app_commands.autocomplete(taxon=taxon_autocomplete, state=state_autocomplete)
+    async def bird_taxons(
+        self,
+        ctx,
+        taxon: str,
+        state: str = "NATS",
+    ):
         logger.info("command: taxons")
 
         taxon = taxon.lower()
@@ -282,16 +335,21 @@ class Other(commands.Cog):
         if taxon not in taxons:
             logger.info("invalid taxon")
             await ctx.send(
-                f"**Sorry, `{taxon}` is not a valid taxon.**\n*Valid taxons:* `{', '.join(map(str, list(taxons.keys())))}`"
+                f"**Sorry, `{taxon if taxon else 'no taxon'}` is not a valid taxon.**\n*Valid taxons:* `{', '.join(map(str, list(taxons.keys())))}`",
+                ephemeral=True,
             )
             return
 
         if state not in states:
             logger.info("invalid state")
             await ctx.send(
-                f"**Sorry, `{state}` is not a valid state.**\n*Valid States:* `{', '.join(map(str, list(states.keys())))}`"
+                f"**Sorry, `{state}` is not a valid state.**\n*Valid States:* `{', '.join(map(str, list(states.keys())))}`",
+                ephemeral=True,
             )
             return
+
+        if ctx.interaction is not None:
+            await ctx.typing()
 
         bird_list = sorted(
             build_id_list(
@@ -312,7 +370,8 @@ class Other(commands.Cog):
         if not bird_list and not song_bird_list:
             logger.info("no birds for taxon/state")
             await ctx.send(
-                "**Sorry, no birds could be found for the taxon/state combo.**\n*Please try again*"
+                "**Sorry, no birds could be found for the taxon/state combo.**\n*Please try again*",
+                ephemeral=True,
             )
             return
 
@@ -341,23 +400,28 @@ class Other(commands.Cog):
         )
 
     # Wiki command - argument is the wiki page
-    @commands.command(
+    @commands.hybrid_command(
         help="- Fetch the wikipedia page for any given argument", aliases=["wiki"]
     )
     @commands.check(CustomCooldown(5.0, bucket=commands.BucketType.user))
+    @app_commands.rename(arg="query")
+    @app_commands.describe(arg="A Wikipedia query")
     async def wikipedia(self, ctx, *, arg):
         logger.info("command: wiki")
         try:
             url = get_wiki_url(arg)
         except wikipedia.exceptions.DisambiguationError:
-            await ctx.send("Sorry, that page was not found. Try being more specific.")
+            await ctx.send(
+                "Sorry, that page was not found. Try being more specific.",
+                ephemeral=True,
+            )
         except wikipedia.exceptions.PageError:
-            await ctx.send("Sorry, that page was not found.")
+            await ctx.send("Sorry, that page was not found.", ephemeral=True)
         else:
             await ctx.send(url)
 
     # meme command - sends a random bird video/gif
-    @commands.command(help="- Sends a funny bird video!")
+    @commands.hybrid_command(help="- Sends a funny bird video!")
     @commands.check(
         CustomCooldown(180.0, disable=True, bucket=commands.BucketType.user)
     )
@@ -377,45 +441,29 @@ class Other(commands.Cog):
         await channel.send(message)
         await ctx.send("Ok, sent!")
 
-    # Test command - for testing purposes only
-    @commands.command(help="- test command", hidden=True)
-    @commands.is_owner()
-    async def cache(self, ctx):
-        logger.info("command: cache stats")
-        items = []
-        with contextlib.suppress(FileNotFoundError):
-            items += os.listdir("bot_files/cache/images/")
-        with contextlib.suppress(FileNotFoundError):
-            items += os.listdir("bot_files/cache/songs/")
-        stats = {
-            "sciname_cache": get_sciname.cache_info(),
-            "taxon_cache": get_taxon.cache_info(),
-            "num_downloaded_birds": len(items),
-        }
-        await ctx.send(f"```python\n{stats}```")
+    # # Test command - for testing purposes only
+    # @commands.command(help="- test command", hidden=True)
+    # @commands.is_owner()
+    # async def cache(self, ctx):
+    #     logger.info("command: cache stats")
+    #     items = []
+    #     with contextlib.suppress(FileNotFoundError):
+    #         items += os.listdir("bot_files/cache/images/")
+    #     with contextlib.suppress(FileNotFoundError):
+    #         items += os.listdir("bot_files/cache/songs/")
+    #     stats = {
+    #         "sciname_cache": get_sciname.cache_info(),
+    #         "taxon_cache": get_taxon.cache_info(),
+    #         "num_downloaded_birds": len(items),
+    #     }
+    #     await ctx.send(f"```python\n{stats}```")
 
-    # Test command - for testing purposes only
-    @commands.command(help="- test command", hidden=True)
-    @commands.is_owner()
-    async def error(self, ctx):
-        logger.info("command: error")
-        await ctx.send(1 / 0)
-
-    # Test command - for testing purposes only
-    @commands.command(help="- test command", hidden=True)
-    @commands.is_owner()
-    async def test(
-        self,
-        ctx,
-        *,
-        user: typing.Optional[typing.Union[discord.Member, discord.User, str]] = None,
-    ):
-        logger.info("command: test")
-        await ctx.send(
-            f"```\nMembers Intent: {self.bot.intents.members}\n"
-            + f"Message Mentions: {ctx.message.mentions}\n"
-            + f"User: {user}\nType: {type(user)}```"
-        )
+    # # Test command - for testing purposes only
+    # @commands.command(help="- test command", hidden=True)
+    # @commands.is_owner()
+    # async def error(self, ctx):
+    #     logger.info("command: error")
+    #     await ctx.send(1 / 0)
 
 
 async def setup(bot):

--- a/bot/cogs/other.py
+++ b/bot/cogs/other.py
@@ -418,5 +418,5 @@ class Other(commands.Cog):
         )
 
 
-def setup(bot):
-    bot.add_cog(Other(bot))
+async def setup(bot):
+    await bot.add_cog(Other(bot))

--- a/bot/cogs/race.py
+++ b/bot/cogs/race.py
@@ -348,5 +348,5 @@ class Race(commands.Cog):
             )
 
 
-def setup(bot):
-    bot.add_cog(Race(bot))
+async def setup(bot):
+    await bot.add_cog(Race(bot))

--- a/bot/cogs/race.py
+++ b/bot/cogs/race.py
@@ -32,7 +32,7 @@ class Race(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
 
-    async def _get_options(self, ctx):
+    async def _get_options(self, ctx: commands.Context):
         filter_int, state, media, limit, taxon, strict, alpha = database.hmget(
             f"race.data:{ctx.channel.id}",
             ["filter", "state", "media", "limit", "taxon", "strict", "alpha"],
@@ -49,7 +49,7 @@ class Race(commands.Cog):
         )
         return options
 
-    async def _send_stats(self, ctx, preamble):
+    async def _send_stats(self, ctx: commands.Context, preamble):
         placings = 5
         database_key = f"race.scores:{ctx.channel.id}"
         if database.zcard(database_key) == 0:
@@ -112,7 +112,7 @@ class Race(commands.Cog):
 
         await ctx.send(embed=embed)
 
-    async def stop_race_(self, ctx):
+    async def stop_race_(self, ctx: commands.Context):
         if Filter.from_int(
             int(database.hget(f"race.data:{ctx.channel.id}", "filter"))
         ).vc:
@@ -160,7 +160,7 @@ class Race(commands.Cog):
         + "Races end when a player is the first to correctly ID a set amount of birds. (default 10)",
     )
     @commands.guild_only()
-    async def race(self, ctx):
+    async def race(self, ctx: commands.Context):
         if ctx.invoked_subcommand is None:
             await ctx.send(
                 "**Invalid subcommand passed.**\n*Valid Subcommands:* `start, view, stop`"
@@ -181,7 +181,7 @@ class Race(commands.Cog):
         args_str="Macaulay Library filters, bird lists, or taxons. Muliple options can be used at once (even if it doesn't autocomplete)"
     )
     @app_commands.autocomplete(args_str=arg_autocomplete)
-    async def start(self, ctx, *, args_str: str = ""):
+    async def start(self, ctx: commands.Context, *, args_str: str = ""):
         logger.info("command: start race")
 
         if not str(ctx.channel.name).startswith("racing"):
@@ -331,7 +331,7 @@ class Race(commands.Cog):
         help="- Views race.\nRaces allow you to compete with your friends to ID a certain bird first.",
     )
     @commands.check(CustomCooldown(3.0, bucket=commands.BucketType.channel))
-    async def view(self, ctx):
+    async def view(self, ctx: commands.Context):
         logger.info("command: view race")
 
         if database.exists(f"race.data:{ctx.channel.id}"):
@@ -343,7 +343,7 @@ class Race(commands.Cog):
 
     @race.command(help="- Stops race", aliases=["stp", "end"])
     @commands.check(CustomCooldown(3.0, bucket=commands.BucketType.channel))
-    async def stop(self, ctx):
+    async def stop(self, ctx: commands.Context):
         logger.info("command: stop race")
 
         if database.exists(f"race.data:{ctx.channel.id}"):

--- a/bot/cogs/race.py
+++ b/bot/cogs/race.py
@@ -18,12 +18,13 @@ import datetime
 import time
 
 import discord
+from discord import app_commands
 from discord.ext import commands
 from discord.utils import escape_markdown as esc
 
 import bot.voice as voice_functions
 from bot.data import database, logger, states, taxons
-from bot.filters import Filter
+from bot.filters import Filter, arg_autocomplete
 from bot.functions import CustomCooldown, fetch_get_user
 
 
@@ -149,7 +150,7 @@ class Race(commands.Cog):
         database.hset(f"channel:{ctx.channel.id}", "bird", "")
         database.hset(f"channel:{ctx.channel.id}", "answered", "1")
 
-    @commands.group(
+    @commands.hybrid_group(
         brief="- Base race command",
         help="- Base race command\n"
         + "Races allow you to compete with others to see who can ID a bird first. "
@@ -175,6 +176,11 @@ class Race(commands.Cog):
         usage="[state] [filters] [taxon] [amount to win (default 10)]",
     )
     @commands.check(CustomCooldown(3.0, bucket=commands.BucketType.channel))
+    @app_commands.rename(args_str="options")
+    @app_commands.describe(
+        args_str="Macaulay Library filters, bird lists, or taxons. Muliple options can be used at once (even if it doesn't autocomplete)"
+    )
+    @app_commands.autocomplete(args_str=arg_autocomplete)
     async def start(self, ctx, *, args_str: str = ""):
         logger.info("command: start race")
 

--- a/bot/cogs/score.py
+++ b/bot/cogs/score.py
@@ -249,7 +249,9 @@ class Score(commands.Cog):
                 score = int(score)
                 user = f"<@{usera}>"
             else:
-                await ctx.send("This user does not exist on our records!")
+                await ctx.send(
+                    "This user does not exist on our records!", ephemeral=True
+                )
                 return
         else:
             user = f"<@{ctx.author.id}>"
@@ -293,7 +295,9 @@ class Score(commands.Cog):
                 max_streak = int(max_streak)
                 user = f"<@{usera}>"
             else:
-                await ctx.send("This user does not exist on our records!")
+                await ctx.send(
+                    "This user does not exist on our records!", ephemeral=True
+                )
                 return
         else:
             user = f"<@{ctx.author.id}>"
@@ -343,7 +347,10 @@ class Score(commands.Cog):
 
         if not scope in ("current", "now", "c", "max", "m"):
             logger.info("invalid scope")
-            await ctx.send(f"**{scope} is not a valid scope!**\n*Valid Scopes:* `max`")
+            await ctx.send(
+                f"**{scope} is not a valid scope!**\n*Valid Scopes:* `max`",
+                ephemeral=True,
+            )
             return
 
         if scope in ("max", "m"):
@@ -396,7 +403,8 @@ class Score(commands.Cog):
         if not scope in ("global", "server", "month", "monthly", "m", "g", "s"):
             logger.info("invalid scope")
             await ctx.send(
-                f"**{scope} is not a valid scope!**\n*Valid Scopes:* `global, server, month`"
+                f"**{scope} is not a valid scope!**\n*Valid Scopes:* `global, server, month`",
+                ephemeral=True,
             )
             return
 
@@ -473,7 +481,8 @@ class Score(commands.Cog):
         ):
             logger.info("invalid scope")
             await ctx.send(
-                f"**{scope} is not a valid scope!**\n*Valid Scopes:* `global, server, me, month`"
+                f"**{scope} is not a valid scope!**\n*Valid Scopes:* `global, server, me, month`",
+                ephemeral=True,
             )
             return
 

--- a/bot/cogs/score.py
+++ b/bot/cogs/score.py
@@ -467,5 +467,5 @@ class Score(commands.Cog):
         )
 
 
-def setup(bot):
-    bot.add_cog(Score(bot))
+async def setup(bot):
+    await bot.add_cog(Score(bot))

--- a/bot/cogs/score.py
+++ b/bot/cogs/score.py
@@ -15,10 +15,11 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import datetime
-import typing
+from typing import Literal, Optional, Union
 
 import discord
 import pandas as pd
+from discord import app_commands
 from discord.ext import commands
 from discord.utils import escape_markdown as esc
 
@@ -31,7 +32,7 @@ class Score(commands.Cog):
         self.bot = bot
 
     @staticmethod
-    def _server_total(ctx):
+    def _server_total(ctx: commands.Context):
         logger.info("fetching server totals")
         channels = map(
             lambda x: x.decode("utf-8"),
@@ -193,13 +194,18 @@ class Score(commands.Cog):
         await ctx.send(embed=embed)
 
     # returns total number of correct answers so far
-    @commands.command(
+    @commands.hybrid_command(
         brief="- Total correct answers in a channel or server",
         help="- Total correct answers in a channel or server. Defaults to channel.",
         usage="[server|s]",
     )
     @commands.check(CustomCooldown(8.0, bucket=commands.BucketType.channel))
-    async def score(self, ctx, scope=""):
+    @app_commands.describe(scope="server or channel")
+    async def score(
+        self,
+        ctx: commands.Context,
+        scope: Literal["server", "channel", "s", "c"] = "channel",
+    ):
         logger.info("command: score")
 
         if scope in ("server", "s"):
@@ -216,18 +222,19 @@ class Score(commands.Cog):
             )
 
     # sends correct answers by a user
-    @commands.command(
+    @commands.hybrid_command(
         brief="- How many correct answers given by a user",
         help="- Gives the amount of correct answers by a user.\n"
         + "Mention someone to get their score, don't mention anyone to get your score.",
         aliases=["us"],
     )
     @commands.check(CustomCooldown(5.0, bucket=commands.BucketType.user))
+    @app_commands.describe(user="The user to check scores for")
     async def userscore(
         self,
-        ctx,
+        ctx: commands.Context,
         *,
-        user: typing.Optional[typing.Union[discord.Member, discord.User, str]] = None,
+        user: Optional[Union[discord.Member, discord.User]] = None,
     ):
         logger.info("command: userscore")
 
@@ -256,13 +263,14 @@ class Score(commands.Cog):
         await ctx.send(embed=embed)
 
     # gives streak of a user
-    @commands.group(
+    @commands.hybrid_group(
         help="- Gives your current/max streak",
         usage="[user]",
         aliases=["streaks", "stk"],
+        fallback="self",
     )
     @commands.check(CustomCooldown(5.0, bucket=commands.BucketType.user))
-    async def streak(self, ctx):
+    async def streak(self, ctx: commands.Context):
         if ctx.invoked_subcommand is not None:
             return
         logger.info("command: streak")
@@ -312,7 +320,13 @@ class Score(commands.Cog):
         aliases=["lb", "top"],
     )
     @commands.check(CustomCooldown(5.0, bucket=commands.BucketType.user))
-    async def streak_leaderboard(self, ctx, scope="", page=1):
+    @app_commands.describe(scope="current or max streaks", page="The page to view")
+    async def streak_leaderboard(
+        self,
+        ctx: commands.Context,
+        scope: Literal["current", "max", "now", "c", "m"] = "current",
+        page: int = 1,
+    ):
         logger.info("command: leaderboard")
 
         try:
@@ -339,19 +353,32 @@ class Score(commands.Cog):
             database_key = "streak:global"
             scope = "current"
 
+        if ctx.interaction is not None:
+            await ctx.typing()
+
         await self.user_lb(
             ctx, f"Streak Leaderboard ({scope})", page, database_key, None
         )
 
     # leaderboard - returns top 1-10 users
-    @commands.command(
+    @commands.hybrid_command(
         brief="- Top scores",
         help="- Top scores, either global, server, or monthly.",
         usage="[global|g  server|s  month|monthly|m] [page]",
         aliases=["lb"],
     )
     @commands.check(CustomCooldown(5.0, bucket=commands.BucketType.user))
-    async def leaderboard(self, ctx, scope="", page=1):
+    @app_commands.describe(
+        scope="global, server, or monthly scores", page="The page to view"
+    )
+    async def leaderboard(
+        self,
+        ctx: commands.Context,
+        scope: Literal[
+            "global", "server", "monthly", "month", "m", "g", "s"
+        ] = "global",
+        page: int = 1,
+    ):
         logger.info("command: leaderboard")
 
         try:
@@ -372,6 +399,9 @@ class Score(commands.Cog):
                 f"**{scope} is not a valid scope!**\n*Valid Scopes:* `global, server, month`"
             )
             return
+
+        if ctx.interaction is not None:
+            await ctx.typing()
 
         if scope in ("server", "s"):
             if ctx.guild is not None:
@@ -398,14 +428,24 @@ class Score(commands.Cog):
         await self.user_lb(ctx, f"Leaderboard ({scope})", page, database_key, data)
 
     # missed - returns top 1-10 missed birds
-    @commands.command(
+    @commands.hybrid_command(
         brief="- Top incorrect birds",
         help="- Top incorrect birds, either global, server, personal, or monthly.",
         usage="[global|g  server|s  me|m  month|monthly|mo] [page]",
         aliases=["m"],
     )
     @commands.check(CustomCooldown(5.0, bucket=commands.BucketType.user))
-    async def missed(self, ctx, scope="", page=1):
+    @app_commands.describe(
+        scope="global, server, personal, or monthly", page="The page to view"
+    )
+    async def missed(
+        self,
+        ctx: commands.Context,
+        scope: Literal[
+            "global", "server", "me", "monthly", "month", "mo", "g", "s", "m"
+        ] = "global",
+        page: int = 1,
+    ):
         logger.info("command: missed")
 
         try:
@@ -436,6 +476,9 @@ class Score(commands.Cog):
                 f"**{scope} is not a valid scope!**\n*Valid Scopes:* `global, server, me, month`"
             )
             return
+
+        if ctx.interaction is not None:
+            await ctx.typing()
 
         if scope in ("server", "s"):
             data = None

--- a/bot/cogs/sessions.py
+++ b/bot/cogs/sessions.py
@@ -31,7 +31,7 @@ class Sessions(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
 
-    async def _get_options(self, ctx):
+    async def _get_options(self, ctx: commands.Context):
         filter_int, state, taxon, wiki, strict = database.hmget(
             f"session.data:{ctx.author.id}",
             ["filter", "state", "taxon", "wiki", "strict"],
@@ -48,7 +48,7 @@ class Sessions(commands.Cog):
         )
         return options
 
-    async def _get_stats(self, ctx):
+    async def _get_stats(self, ctx: commands.Context):
         start, correct, incorrect, total = map(
             int,
             database.hmget(
@@ -73,7 +73,7 @@ class Sessions(commands.Cog):
         )
         return stats
 
-    async def _send_stats(self, ctx, preamble):
+    async def _send_stats(self, ctx: commands.Context, preamble):
         database_key = f"session.incorrect:{ctx.author.id}"
 
         embed = discord.Embed(
@@ -112,7 +112,7 @@ class Sessions(commands.Cog):
         + "state specific bird lists, specific bird taxons, or bird age/sex. ",
         aliases=["ses", "sesh"],
     )
-    async def session(self, ctx):
+    async def session(self, ctx: commands.Context):
         if ctx.invoked_subcommand is None:
             await ctx.send(
                 "**Invalid subcommand passed.**\n*Valid Subcommands:* `start, view, stop`"
@@ -134,7 +134,7 @@ class Sessions(commands.Cog):
         args_str="Macaulay Library filters, bird lists, or taxons. Muliple options can be used at once (even if it doesn't autocomplete)"
     )
     @app_commands.autocomplete(args_str=arg_autocomplete)
-    async def start(self, ctx, *, args_str: str = ""):
+    async def start(self, ctx: commands.Context, *, args_str: str = ""):
         logger.info("command: start session")
 
         if database.exists(f"session.data:{ctx.author.id}"):
@@ -216,7 +216,7 @@ class Sessions(commands.Cog):
         args_str="Macaulay Library filters, bird lists, or taxons. Muliple options can be used at once (even if it doesn't autocomplete)"
     )
     @app_commands.autocomplete(args_str=arg_autocomplete)
-    async def edit(self, ctx, *, args_str: str = ""):
+    async def edit(self, ctx: commands.Context, *, args_str: str = ""):
         logger.info("command: view session")
 
         if not database.exists(f"session.data:{ctx.author.id}"):
@@ -295,7 +295,7 @@ class Sessions(commands.Cog):
     # stops session
     @session.command(help="- Stops session", aliases=["stp", "end"])
     @commands.check(CustomCooldown(3.0, bucket=commands.BucketType.user))
-    async def stop(self, ctx):
+    async def stop(self, ctx: commands.Context):
         logger.info("command: stop session")
 
         if database.exists(f"session.data:{ctx.author.id}"):

--- a/bot/cogs/sessions.py
+++ b/bot/cogs/sessions.py
@@ -303,5 +303,5 @@ class Sessions(commands.Cog):
             )
 
 
-def setup(bot):
-    bot.add_cog(Sessions(bot))
+async def setup(bot):
+    await bot.add_cog(Sessions(bot))

--- a/bot/cogs/sessions.py
+++ b/bot/cogs/sessions.py
@@ -19,10 +19,11 @@ import textwrap
 import time
 
 import discord
+from discord import app_commands
 from discord.ext import commands
 
 from bot.data import database, logger, states, taxons
-from bot.filters import Filter
+from bot.filters import Filter, arg_autocomplete
 from bot.functions import CustomCooldown, check_state_role
 
 
@@ -102,7 +103,7 @@ class Sessions(commands.Cog):
 
         await ctx.send(embed=embed)
 
-    @commands.group(
+    @commands.hybrid_group(
         brief="- Base session command",
         help="- Base session command\n"
         + "Sessions will record your activity for an amount of time and "
@@ -128,6 +129,11 @@ class Sessions(commands.Cog):
         usage="[state] [taxons] [filters]",
     )
     @commands.check(CustomCooldown(3.0, bucket=commands.BucketType.user))
+    @app_commands.rename(args_str="options")
+    @app_commands.describe(
+        args_str="Macaulay Library filters, bird lists, or taxons. Muliple options can be used at once (even if it doesn't autocomplete)"
+    )
+    @app_commands.autocomplete(args_str=arg_autocomplete)
     async def start(self, ctx, *, args_str: str = ""):
         logger.info("command: start session")
 
@@ -205,6 +211,11 @@ class Sessions(commands.Cog):
         usage="[state] [taxons] [filters]",
     )
     @commands.check(CustomCooldown(3.0, bucket=commands.BucketType.user))
+    @app_commands.rename(args_str="options")
+    @app_commands.describe(
+        args_str="Macaulay Library filters, bird lists, or taxons. Muliple options can be used at once (even if it doesn't autocomplete)"
+    )
+    @app_commands.autocomplete(args_str=arg_autocomplete)
     async def edit(self, ctx, *, args_str: str = ""):
         logger.info("command: view session")
 

--- a/bot/cogs/skip.py
+++ b/bot/cogs/skip.py
@@ -28,9 +28,9 @@ class Skip(commands.Cog):
         self.bot = bot
 
     # Skip command - no args
-    @commands.command(help="- Skip the current bird to get a new one", aliases=["sk"])
+    @commands.hybrid_command(help="- Skip the current bird to get a new one", aliases=["sk"])
     @commands.check(CustomCooldown(5.0, bucket=commands.BucketType.channel))
-    async def skip(self, ctx):
+    async def skip(self, ctx: commands.Context):
         logger.info("command: skip")
 
         currentBird = database.hget(f"channel:{ctx.channel.id}", "bird").decode("utf-8")

--- a/bot/cogs/skip.py
+++ b/bot/cogs/skip.py
@@ -69,5 +69,5 @@ class Skip(commands.Cog):
             await ctx.send("You need to ask for a bird first!")
 
 
-def setup(bot):
-    bot.add_cog(Skip(bot))
+async def setup(bot):
+    await bot.add_cog(Skip(bot))

--- a/bot/cogs/state.py
+++ b/bot/cogs/state.py
@@ -65,7 +65,7 @@ class States(commands.Cog):
     @app_commands.describe(args="the bird list")
     @app_commands.rename(args="list")
     @app_commands.autocomplete(args=state_autocomplete)
-    async def state(self, ctx, *, args: str):
+    async def state(self, ctx: commands.Context, *, args: str):
         logger.info("command: state set")
 
         raw_roles = ctx.author.roles
@@ -161,8 +161,10 @@ class States(commands.Cog):
     @commands.dm_only()
     async def custom(
         self,
-        ctx,
-        command: Literal["replace", "delete", "confirm", "validate", "view", "set"] = "set",
+        ctx: commands.Context,
+        command: Literal[
+            "replace", "delete", "confirm", "validate", "view", "set"
+        ] = "set",
         attachment: Optional[discord.Attachment] = None,
     ):
         logger.info("command: custom list set")

--- a/bot/cogs/state.py
+++ b/bot/cogs/state.py
@@ -345,9 +345,7 @@ class States(commands.Cog):
 
     async def validate(self, ctx, parsed_birdlist):
         validated_birdlist = []
-        async with aiohttp.ClientSession(
-            cookie_jar=(await cookies())
-        ) as session:
+        async with aiohttp.ClientSession(cookie_jar=(await cookies())) as session:
             logger.info("starting validation")
             await ctx.send("**Validating bird list...**\n*This may take a while.*")
             invalid_output = []
@@ -414,5 +412,5 @@ class States(commands.Cog):
             await handle_error(ctx, error)
 
 
-def setup(bot):
-    bot.add_cog(States(bot))
+async def setup(bot):
+    await bot.add_cog(States(bot))

--- a/bot/cogs/stats.py
+++ b/bot/cogs/stats.py
@@ -481,5 +481,5 @@ class Stats(commands.Cog):
         await ctx.send(files=files)
 
 
-def setup(bot):
-    bot.add_cog(Stats(bot))
+async def setup(bot):
+    await bot.add_cog(Stats(bot))

--- a/bot/cogs/voice.py
+++ b/bot/cogs/voice.py
@@ -29,60 +29,62 @@ class Voice(commands.Cog):
     def cog_unload(self):
         self.cleanup.cancel()
 
-    @commands.command(help="- Play a sound")
+    @commands.hybrid_command(help="- Play a sound")
     @commands.check(CustomCooldown(3.0, bucket=commands.BucketType.channel))
     @commands.guild_only()
-    async def play(self, ctx):
+    async def play(self, ctx: commands.Context):
         logger.info("command: play")
         await voice_functions.play(ctx, None)
 
-    @commands.command(help="- Pause playing")
+    @commands.hybrid_command(help="- Pause playing")
     @commands.check(CustomCooldown(3.0, bucket=commands.BucketType.channel))
     @commands.guild_only()
-    async def pause(self, ctx):
+    async def pause(self, ctx: commands.Context):
         logger.info("command: pause")
         await voice_functions.pause(ctx)
 
-    @commands.command(help="- Stop playing")
+    @commands.hybrid_command(help="- Stop playing")
     @commands.check(CustomCooldown(3.0, bucket=commands.BucketType.channel))
     @commands.guild_only()
-    async def stop(self, ctx):
+    async def stop(self, ctx: commands.Context):
         logger.info("command: stop")
         await voice_functions.stop(ctx)
 
-    @commands.command(help="- Skip forward 5 seconds", aliases=["fw", "forwards"])
+    @commands.hybrid_command(
+        help="- Skip forward 5 seconds", aliases=["fw", "forwards"]
+    )
     @commands.check(CustomCooldown(2.0, bucket=commands.BucketType.channel))
     @commands.guild_only()
-    async def forward(self, ctx, seconds: int = 5):
+    async def forward(self, ctx: commands.Context, seconds: int = 5):
         logger.info("command: forward")
         if seconds < 1:
             await ctx.send("Invalid number of seconds!")
             return
         await voice_functions.rel_seek(ctx, seconds)
 
-    @commands.command(
+    @commands.hybrid_command(
         help="- Skip back 5 seconds", aliases=["bk", "backward", "backwards"]
     )
     @commands.check(CustomCooldown(2.0, bucket=commands.BucketType.channel))
     @commands.guild_only()
-    async def back(self, ctx, seconds: int = 5):
+    async def back(self, ctx: commands.Context, seconds: int = 5):
         logger.info("command: back")
         if seconds < 1:
             await ctx.send("Invalid number of seconds!")
             return
         await voice_functions.rel_seek(ctx, seconds * -1)
 
-    @commands.command(help="- Replay", aliases=["rp", "re"])
+    @commands.hybrid_command(help="- Replay", aliases=["rp", "re"])
     @commands.check(CustomCooldown(2.0, bucket=commands.BucketType.channel))
     @commands.guild_only()
-    async def replay(self, ctx):
+    async def replay(self, ctx: commands.Context):
         logger.info("command: replay")
         await voice_functions.rel_seek(ctx, None)
 
-    @commands.command(help="- Disconnect from voice", aliases=["dc"])
+    @commands.hybrid_command(help="- Disconnect from voice", aliases=["dc"])
     @commands.check(CustomCooldown(3.0, bucket=commands.BucketType.channel))
     @commands.guild_only()
-    async def disconnect(self, ctx):
+    async def disconnect(self, ctx: commands.Context):
         logger.info("command: disconnect")
         current_voice = database.get(f"voice.server:{ctx.guild.id}")
         if current_voice is not None:

--- a/bot/cogs/voice.py
+++ b/bot/cogs/voice.py
@@ -97,5 +97,5 @@ class Voice(commands.Cog):
         await voice_functions.cleanup(self.bot)
 
 
-def setup(bot):
-    bot.add_cog(Voice(bot))
+async def setup(bot):
+    await bot.add_cog(Voice(bot))

--- a/bot/core.py
+++ b/bot/core.py
@@ -291,7 +291,8 @@ async def send_bird(
         filename, extension = await get_media(ctx, bird, media_type, filters)
         macaulay_asset_id = filename.split("/")[-1].split(".")[0]
     except GenericError as e:
-        await delete.delete()
+        if ctx.interaction is None:
+            await delete.delete()
         if e.code == 100:
             await ctx.send(
                 f"**This combination of filters has no valid {media_type.name()} for the current bird.**"
@@ -317,7 +318,8 @@ async def send_bird(
         return
 
     if os.stat(filename).st_size > MAX_FILESIZE:  # another filesize check (4mb)
-        await delete.delete()
+        if ctx.interaction is None:
+            await delete.delete()
         await ctx.send(
             "**Oops! File too large :(**\n*Please try again.*", ephemeral=True
         )

--- a/bot/core.py
+++ b/bot/core.py
@@ -284,7 +284,8 @@ async def send_bird(
 
     delete = await ctx.send("**Fetching.** This may take a while.")
     # trigger "typing" discord message
-    await ctx.typing()
+    if ctx.interaction is None:
+        await ctx.typing()
 
     try:
         filename, extension = await get_media(ctx, bird, media_type, filters)

--- a/bot/core.py
+++ b/bot/core.py
@@ -284,7 +284,7 @@ async def send_bird(
 
     delete = await ctx.send("**Fetching.** This may take a while.")
     # trigger "typing" discord message
-    await ctx.trigger_typing()
+    await ctx.typing()
 
     try:
         filename, extension = await get_media(ctx, bird, media_type, filters)

--- a/bot/functions.py
+++ b/bot/functions.py
@@ -622,7 +622,7 @@ class CustomCooldown:
 
         retry_after = bucket.update_rate_limit()
         if retry_after:
-            raise commands.CommandOnCooldown(bucket, retry_after)
+            raise commands.CommandOnCooldown(self, retry_after, bucket)
         return True
 
 

--- a/bot/functions.py
+++ b/bot/functions.py
@@ -667,6 +667,12 @@ async def handle_error(ctx, error):
             ephemeral=True,
         )
 
+    elif isinstance(error, commands.BadLiteralArgument):
+        await ctx.send(
+            f"The argument passed was invalid.\n**Valid Arguments:** `{'`, `'.join(error.literals)}`.",
+            ephemeral=True,
+        )
+
     elif isinstance(error, commands.BotMissingPermissions):
         await ctx.send(
             "**The bot does not have enough permissions to fully function.**\n"

--- a/bot/functions.py
+++ b/bot/functions.py
@@ -628,7 +628,6 @@ class CustomCooldown:
 
 async def handle_error(ctx, error):
     """Function for comprehensive error handling."""
-
     if isinstance(error, commands.CommandOnCooldown):  # send cooldown
         await ctx.send(
             (
@@ -640,43 +639,67 @@ async def handle_error(ctx, error):
             + str(round(error.retry_after, 2))
             + " s.",
             delete_after=5.0,
+            ephemeral=True,
         )
 
     elif isinstance(error, commands.CommandNotFound):
         capture_exception(error)
-        await ctx.send("Sorry, the command was not found.")
+        await ctx.send(
+            "Sorry, the command was not found.",
+            ephemeral=True,
+        )
 
     elif isinstance(error, commands.MissingRequiredArgument):
-        await ctx.send("This command requires an argument!")
+        await ctx.send(
+            "This command requires an argument!",
+            ephemeral=True,
+        )
 
     elif isinstance(error, commands.BadArgument):
-        await ctx.send("The argument passed was invalid. Please try again.")
+        await ctx.send(
+            "The argument passed was invalid. Please try again.",
+            ephemeral=True,
+        )
 
     elif isinstance(error, commands.ArgumentParsingError):
-        await ctx.send("An invalid character was detected. Please try again.")
+        await ctx.send(
+            "An invalid character was detected. Please try again.",
+            ephemeral=True,
+        )
 
     elif isinstance(error, commands.BotMissingPermissions):
         await ctx.send(
             "**The bot does not have enough permissions to fully function.**\n"
-            + f"**Permissions Missing:** `{', '.join(map(str, error.missing_perms))}`\n"
-            + "*Please try again once the correct permissions are set.*"
+            + f"**Permissions Missing:** `{', '.join(map(str, error.missing_permissions))}`\n"
+            + "*Please try again once the correct permissions are set.*",
+            ephemeral=True,
         )
 
     elif isinstance(error, commands.MissingPermissions):
         await ctx.send(
             "You do not have the required permissions to use this command.\n"
-            + f"**Required Perms:** `{'`, `'.join(error.missing_perms)}`"
+            + f"**Required Perms:** `{'`, `'.join(error.missing_permissions)}`",
+            ephemeral=True,
         )
 
     elif isinstance(error, commands.NoPrivateMessage):
-        await ctx.send("**This command is unavailable in DMs!**")
+        await ctx.send(
+            "**This command is unavailable in DMs!**",
+            ephemeral=True,
+        )
 
     elif isinstance(error, commands.PrivateMessageOnly):
-        await ctx.send("**This command is only available in DMs!**")
+        await ctx.send(
+            "**This command is only available in DMs!**",
+            ephemeral=True,
+        )
 
     elif isinstance(error, commands.NotOwner):
         logger.info("not owner")
-        await ctx.send("Sorry, the command was not found.")
+        await ctx.send(
+            "Sorry, the command was not found.",
+            ephemeral=True,
+        )
 
     elif isinstance(error, GenericError):
         if error.code == 192:
@@ -691,7 +714,8 @@ async def handle_error(ctx, error):
             logger.info("HTTP Error")
             capture_exception(error)
             await ctx.send(
-                "**An unexpected HTTP Error has occurred.**\n *Please try again.*"
+                "**An unexpected HTTP Error has occurred.**\n *Please try again.*",
+                ephemeral=True,
             )
         else:
             logger.info("uncaught generic error")
@@ -699,9 +723,10 @@ async def handle_error(ctx, error):
             await ctx.send(
                 "**An uncaught generic error has occurred.**\n"
                 + "*Please log this message in #support in the support server below, or try again.*\n"
-                + f"**Error code:** `{error.code}`"
+                + f"**Error code:** `{error.code}`\n"
+                + "https://discord.gg/2HbshwGjnm",
+                ephemeral=True,
             )
-            await ctx.send("https://discord.gg/2HbshwGjnm")
             raise error
 
     elif isinstance(error, commands.CommandInvokeError):
@@ -711,75 +736,101 @@ async def handle_error(ctx, error):
                 await ctx.send(
                     "**An unexpected ResponseError has occurred.**\n"
                     + "*Please log this message in #support in the support server below, or try again.*\n"
+                    + "https://discord.gg/2HbshwGjnm",
+                    ephemeral=True,
                 )
-                await ctx.send("https://discord.gg/2HbshwGjnm")
             else:
                 await channel_setup(ctx)
-                await ctx.send("Please run that command again.")
+                await ctx.send(
+                    "Please run that command again.",
+                    ephemeral=True,
+                )
 
         elif isinstance(error.original, wikipedia.exceptions.DisambiguationError):
-            await ctx.send("Wikipedia page not found. (Disambiguation Error)")
+            await ctx.send(
+                "Wikipedia page not found. (Disambiguation Error)",
+                ephemeral=True,
+            )
 
         elif isinstance(error.original, wikipedia.exceptions.PageError):
-            await ctx.send("Wikipedia page not found. (Page Error)")
+            await ctx.send(
+                "Wikipedia page not found. (Page Error)",
+                ephemeral=True,
+            )
 
         elif isinstance(error.original, wikipedia.exceptions.WikipediaException):
             capture_exception(error.original)
-            await ctx.send("Wikipedia page unavailable. Try again later.")
+            await ctx.send(
+                "Wikipedia page unavailable. Try again later.",
+                ephemeral=True,
+            )
 
         elif isinstance(error.original, discord.Forbidden):
             if error.original.code == 50007:
                 await ctx.send(
-                    "I was unable to DM you. Check if I was blocked and try again."
+                    "I was unable to DM you. Check if I was blocked and try again.",
+                    ephemeral=True,
                 )
             elif error.original.code == 50013:
                 await ctx.send(
-                    "There was an error with permissions. Check the bot has proper permissions and try again."
+                    "There was an error with permissions. Check the bot has proper permissions and try again.",
+                    ephemeral=True,
                 )
             else:
                 capture_exception(error)
                 await ctx.send(
                     "**An unexpected Forbidden error has occurred.**\n"
                     + "*Please log this message in #support in the support server below, or try again.*\n"
-                    + f"**Error code:** `{error.original.code}`"
+                    + f"**Error code:** `{error.original.code}`\n"
+                    + "https://discord.gg/2HbshwGjnm",
+                    ephemeral=True,
                 )
-                await ctx.send("https://discord.gg/2HbshwGjnm")
 
         elif isinstance(error.original, discord.HTTPException):
             capture_exception(error.original)
             if error.original.status == 502:
                 await ctx.send(
-                    "**An error has occurred with discord. :(**\n*Please try again.*"
+                    "**An error has occurred with discord. :(**\n*Please try again.*",
+                    ephemeral=True,
                 )
             else:
                 await ctx.send(
                     "**An unexpected HTTPException has occurred.**\n"
                     + "*Please log this message in #support in the support server below, or try again*\n"
-                    + f"**Reponse Code:** `{error.original.status}`"
+                    + f"**Reponse Code:** `{error.original.status}`\n"
+                    + "https://discord.gg/2HbshwGjnm",
+                    ephemeral=True,
                 )
-                await ctx.send("https://discord.gg/2HbshwGjnm")
 
         elif isinstance(error.original, aiohttp.ClientOSError):
             capture_exception(error.original)
             if error.original.errno == errno.ECONNRESET:
                 await ctx.send(
-                    "**An error has occurred with discord. :(**\n*Please try again.*"
+                    "**An error has occurred with discord. :(**\n*Please try again.*",
+                    ephemeral=True,
                 )
             else:
                 await ctx.send(
                     "**An unexpected ClientOSError has occurred.**\n"
                     + "*Please log this message in #support in the support server below, or try again.*\n"
-                    + f"**Error code:** `{error.original.errno}`"
+                    + f"**Error code:** `{error.original.errno}`\n"
+                    + "https://discord.gg/2HbshwGjnm",
+                    ephemeral=True,
                 )
-                await ctx.send("https://discord.gg/2HbshwGjnm")
 
         elif isinstance(error.original, aiohttp.ServerDisconnectedError):
             capture_exception(error.original)
-            await ctx.send("**The server disconnected.**\n*Please try again.*")
+            await ctx.send(
+                "**The server disconnected.**\n*Please try again.*",
+                ephemeral=True,
+            )
 
         elif isinstance(error.original, asyncio.TimeoutError):
             capture_exception(error.original)
-            await ctx.send("**The request timed out.**\n*Please try again in a bit.*")
+            await ctx.send(
+                "**The request timed out.**\n*Please try again in a bit.*",
+                ephemeral=True,
+            )
 
         elif isinstance(error.original, OSError):
             capture_exception(error.original)
@@ -787,15 +838,17 @@ async def handle_error(ctx, error):
                 await ctx.send(
                     "**No space is left on the server!**\n"
                     + "*Please report this message in #support in the support server below!*\n"
+                    + "https://discord.gg/2HbshwGjnm",
+                    ephemeral=True,
                 )
-                await ctx.send("https://discord.gg/2HbshwGjnm")
             else:
                 await ctx.send(
                     "**An unexpected OSError has occurred.**\n"
                     + "*Please log this message in #support in the support server below, or try again.*\n"
-                    + f"**Error code:** `{error.original.errno}`"
+                    + f"**Error code:** `{error.original.errno}`\n"
+                    + "https://discord.gg/2HbshwGjnm",
+                    ephemeral=True,
                 )
-                await ctx.send("https://discord.gg/2HbshwGjnm")
 
         else:
             logger.info("uncaught command error")
@@ -803,8 +856,9 @@ async def handle_error(ctx, error):
             await ctx.send(
                 "**An uncaught command error has occurred.**\n"
                 + "*Please log this message in #support in the support server below, or try again.*\n"
+                + "https://discord.gg/2HbshwGjnm",
+                ephemeral=True,
             )
-            await ctx.send("https://discord.gg/2HbshwGjnm")
             raise error
 
     else:
@@ -813,6 +867,7 @@ async def handle_error(ctx, error):
         await ctx.send(
             "**An uncaught non-command error has occurred.**\n"
             + "*Please log this message in #support in the support server below, or try again.*\n"
+            + "https://discord.gg/2HbshwGjnm",
+            ephemeral=True,
         )
-        await ctx.send("https://discord.gg/2HbshwGjnm")
         raise error

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-discord.py[voice]==1.7.3
+discord.py[voice]==2.1.0
 wikipedia==1.4.0
 Pillow==9.1.1
 eyeD3==0.9.6
@@ -18,3 +18,4 @@ uvicorn[standard]==0.17.6
 httpx==0.23.0
 aiofiles==0.8.0
 pycryptodome==3.15.0
+chardet==5.0.0


### PR DESCRIPTION
This PR adds support for slash commands by updating commands to use the `hybrid_commands` decorator.

Due to limitations with slash command permissions, owner-only commands remain as message based commands.